### PR TITLE
Disable fhir server proxy

### DIFF
--- a/backend/config.ts
+++ b/backend/config.ts
@@ -60,5 +60,11 @@ export default {
     /**
      * Our private key as PEM (used to generate the JWKS at /keys)
      */
-    privateKeyAsPem: FS.readFileSync(__dirname + "/../private-key.pem", "utf8")
-}
+    privateKeyAsPem: FS.readFileSync(__dirname + "/../private-key.pem", "utf8"),
+
+    /**
+     * Proxy requests to the FHIR server. Defaults to true. Can be disabled 
+     * if the FHIR server has its own .well-known/smart-configuration
+     */
+    proxyFhirRequests: env.PROXY_FHIR_REQUESTS !== "false",
+};

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -75,7 +75,8 @@ app.use("/env.js", (_, res) => {
         FHIR_SERVER_R4     : config.fhirServerR4,
         ACCESS_TOKEN       : jwt.sign({ client_id: "launcherUI" }, config.jwtSecret, { expiresIn: "10 years" }),
         VERSION            : pkg.version,
-        COMMIT             : process.env.SOURCE_VERSION
+        COMMIT             : process.env.SOURCE_VERSION,
+        PROXY_FHIR_REQUESTS: process.env.PROXY_FHIR_REQUESTS !== "false",
     };
 
     res.type("application/javascript").send(`var ENV = ${JSON.stringify(out, null, 4)};`);

--- a/example.env
+++ b/example.env
@@ -41,3 +41,6 @@ REFRESH_TOKEN_LIFETIME =
 
 # Comma-separated list of IPs that are not sllowed to access this service
 IP_BLACK_LIST = ""
+
+# Proxy requests to the FHIR server. Defaults to true. Can be disabled if the FHIR server has its own .well-known/smart-configuration
+PROXY_FHIR_REQUESTS = "true"

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ declare global {
         ACCESS_TOKEN       : string
         VERSION            : string
         COMMIT             : string
+        PROXY_FHIR_REQUESTS: boolean
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "smart-launcher",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "smart-launcher",
-      "version": "2.0.0",
+      "version": "2.0.1",
+      "hasInstallScript": true,
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.3.0",
@@ -54,6 +55,9 @@
         "nyc": "^15.1.0",
         "selenium-webdriver": "^4.4.0",
         "ts-mocha": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/src/components/Launcher/index.tsx
+++ b/src/components/Launcher/index.tsx
@@ -131,7 +131,9 @@ export default function Launcher() {
     const aud = `${backendOrigin}/v/${fhir_version}/sim/${launchCode}/fhir`;
 
     // FHIR baseUrl for EHR launches
-    const iss = `${backendOrigin}/v/${fhir_version}/fhir`;
+    const iss = ENV.PROXY_FHIR_REQUESTS
+        ? `${backendOrigin}/v/${fhir_version}/fhir`
+        : (ENV as any)[`FHIR_SERVER_${fhir_version.toUpperCase()}`];
 
     // The URL to launch the sample app
     let sampleLaunchUrl = new URL(


### PR DESCRIPTION
## Overview

- Added `PROXY_FHIR_REQUESTS` config option (defaults to true)
- When `PROXY_FHIR_REQUESTS` is false, it uses the real fhir server URL as iss param for EHR launch.

## How it was tested

- Ran the launcher locally with config:
  - `FHIR_SERVER_R2 = "https://fhir2-internal.elimuinformatics.com/baseDstu2"`
  - `PROXY_FHIR_REQUESTS = "false"`
- Tested a Provider EHR launch for an app running on localhost
- Used Chrome dev tools to verify that the app is launched with `iss=https://fhir2-internal.elimuinformatics.com/baseDstu2` and that the app requests `.well-known/smart-configuration` directly from the FHIR server.
- Ran the launcher locally with `PROXY_FHIR_REQUESTS = "true"` (and also undefined) and verified that original proxy behavior is unchanged.

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
