### PR TITLE
docker permission fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ USER node
 WORKDIR /home/node
 COPY package*.json ./
 COPY --chown=node . .
-RUN npm ci --production=false
+RUN npm ci
 RUN npm run build
+RUN npm ci --omit=dev
 
 # Final Image
 FROM node:18 AS final
@@ -14,10 +15,10 @@ WORKDIR /app
 ENV NODE_ENV "production"
 ENV PORT "80"
 COPY package*.json ./
-RUN npm ci --production=true
 COPY backend ./backend
 COPY src/isomorphic ./src/isomorphic
 COPY *.pem ./
 COPY --from=build /home/node/build ./build
+COPY --from=build /home/node/node_modules ./node_modules
 EXPOSE 80
 CMD ["/app/node_modules/.bin/ts-node", "--skipProject", "--transpile-only", "./backend/index.ts"]


### PR DESCRIPTION
## Overview

- Moved production npm install to build stage and copy node_modules dir into final image
- This fixes a permission issue during npm install

## How it was tested

- Ran docker image locally

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
