### PR TITLE
Fix aud verification when proxy disabled

### DIFF
--- a/backend/lib.ts
+++ b/backend/lib.ts
@@ -44,7 +44,7 @@ export function notSupported(message: string = "", code = 400) {
     };
 }
 
-export function getFhirServerBaseUrl(req: Request) {
+export function getFhirServerBaseUrl(req: { params: { fhir_release: string }}) {
     const fhirVersion = req.params.fhir_release.toUpperCase();
     let fhirServer = config[`fhirServer${fhirVersion}` as keyof typeof config] as string;
 

--- a/backend/lib.ts
+++ b/backend/lib.ts
@@ -2,7 +2,7 @@ import jwt from "jsonwebtoken"
 import { NextFunction, Request, Response, RequestHandler } from "express"
 import config from "./config";
 import { HttpError, InvalidRequestError } from "./errors";
-
+import { SMART } from "..";
 
 /**
  * Given a request object, returns its base URL
@@ -44,7 +44,7 @@ export function notSupported(message: string = "", code = 400) {
     };
 }
 
-export function getFhirServerBaseUrl(req: { params: { fhir_release: string }}) {
+export function getFhirServerBaseUrl(req: Request | SMART.AuthorizeRequest) {
     const fhirVersion = req.params.fhir_release.toUpperCase();
     let fhirServer = config[`fhirServer${fhirVersion}` as keyof typeof config] as string;
 

--- a/backend/routes/auth/authorize.ts
+++ b/backend/routes/auth/authorize.ts
@@ -432,7 +432,9 @@ export default class AuthorizeHandler {
 
         // The "aud" param must match the apiUrl (but can have different protocol)
         // console.log(req.url, req.baseUrl)
-        const apiUrl = new URL(request.baseUrl.replace(/\/auth.*$/, "/fhir"), this.baseUrl)
+        const apiUrl = config.proxyFhirRequests
+          ? new URL(request.baseUrl.replace(/\/auth.*$/, "/fhir"), this.baseUrl)
+          : new URL(getFhirServerBaseUrl(request));
         const apiUrlHref = apiUrl.href
 
         let audUrl: URL        


### PR DESCRIPTION
## Overview

- `AuthorizeHandler` now verifies `aud` claim against the FHIR server URL instead of the launcher URL when `PROXY_FHIR_REQUESTS = "false"`

## How it was tested

- Ran launcher locally and did a quick sanity check
- Could not test aud verification without proxy when running locally

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)