### PR TITLE
Ignore failure when auto-selecting encounter

### DIFF
--- a/backend/routes/auth/authorize.ts
+++ b/backend/routes/auth/authorize.ts
@@ -293,12 +293,8 @@ export default class AuthorizeHandler {
                 }
             )
             .catch(() => {
-                this.response.status(400)
-                this.response.json({
-                    error: "invalid_request",
-                    error_description: "Failed to auto-select the first encounter for " +
-                        `patient with id of '${this.launchOptions.patient.get(0)}'`
-                })
+                this.launchOptions.encounter = "NONE";
+                this.authorize();
             })
         } else {
             this.redirect("/select-encounter", {
@@ -449,7 +445,7 @@ export default class AuthorizeHandler {
 
         apiUrl.hostname = apiUrl.hostname.replace(/^:\/\/localhost/, "://127.0.0.1")
         audUrl.hostname = apiUrl.hostname.replace(/^:\/\/localhost/, "://127.0.0.1")
-
+        console.log(apiUrl.href, audUrl.href);
         if (apiUrl.href !== audUrl.href) {
             throw new InvalidRequestError('Bad audience value "%s". Expected "%s".', params.aud, apiUrlHref)
         }

--- a/backend/routes/auth/authorize.ts
+++ b/backend/routes/auth/authorize.ts
@@ -445,7 +445,7 @@ export default class AuthorizeHandler {
 
         apiUrl.hostname = apiUrl.hostname.replace(/^:\/\/localhost/, "://127.0.0.1")
         audUrl.hostname = apiUrl.hostname.replace(/^:\/\/localhost/, "://127.0.0.1")
-        console.log(apiUrl.href, audUrl.href);
+
         if (apiUrl.href !== audUrl.href) {
             throw new InvalidRequestError('Bad audience value "%s". Expected "%s".', params.aud, apiUrlHref)
         }


### PR DESCRIPTION
## Overview

- This is a (temporary?) workaround for error message "Failed to auto-select the first encounter"
- Instead of throwing an error, just launch with no encounter in the context.

## How it was tested

- Ran launcher and hapi-fhir locally with `PROXY_FHIR_SERVER = "false"`
- Launched an app running on localhost

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)