### PR TITLE
Jenkinsfile - push to prod ECR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,6 @@ pipeline {
     buildDiscarder(logRotator(numToKeepStr: '10'))
   }
   environment {
-    AWS_ACCOUNTS = '435911253355'
     AWS_CREDENTIALS = credentials('AWS-KEYS')
     AWS_ENV = """${sh(
       returnStdout: true,


### PR DESCRIPTION
## Overview

- Removed AWS_ACCOUNTS var from Jenkinsfile so it will push the image to both internal and prod ECR

## How it was tested

- Not tested

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [ ] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)