### PR TITLE
RT-1023:(smart-launcher-v2) No encounter in launch context

### DIFF
--- a/backend/routes/auth/authorize.ts
+++ b/backend/routes/auth/authorize.ts
@@ -586,7 +586,10 @@ export default class AuthorizeHandler {
     }
 
     private async getFirstEncounterId(): Promise<string | undefined> {
-        const fhirServer = getFhirServerBaseUrl(this.request as any);
+        let fhirServer = getFhirServerBaseUrl(this.request as any);
+        if (!fhirServer.endsWith('/')) {
+            fhirServer = fhirServer + '/';
+        } 
         const url = new URL(`Encounter/?_count=1&_sort:desc=date`, fhirServer)
         url.searchParams.set("patient", this.launchOptions.patient.get(0)!)
         const res = await fetch(url)


### PR DESCRIPTION
Updated a code so launcher-v2 adds the trailing slash when building the Encounter request (and any other places where it uses URL constructor) instead of adding the slash to the env var.